### PR TITLE
chore(example): split lib and bin to remove duplicate-target warning

### DIFF
--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -5,12 +5,13 @@ edition.workspace = true
 license.workspace = true
 
 [lib]
-crate-type = ["cdylib"]
+crate-type = ["rlib", "cdylib"]
 name = "example"
+path = "src/lib.rs"
 
 [[bin]]
 name = "example"
-path = "src/lib.rs"
+path = "src/main.rs"
 
 [dependencies]
 tessera-ui = { path = "../tessera-ui" }

--- a/example/src/lib.rs
+++ b/example/src/lib.rs
@@ -44,7 +44,6 @@ fn android_main(android_app: AndroidApp) {
 #[cfg(target_os = "android")]
 fn main() {}
 
-#[allow(dead_code)]
 #[cfg(not(target_os = "android"))]
 pub fn desktop_main() -> Result<(), Box<dyn std::error::Error>> {
     let _logger = flexi_logger::Logger::try_with_env()?

--- a/example/src/lib.rs
+++ b/example/src/lib.rs
@@ -46,7 +46,7 @@ fn main() {}
 
 #[allow(dead_code)]
 #[cfg(not(target_os = "android"))]
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+pub fn desktop_main() -> Result<(), Box<dyn std::error::Error>> {
     let _logger = flexi_logger::Logger::try_with_env()?
         .write_mode(flexi_logger::WriteMode::Async)
         .start()?;

--- a/example/src/main.rs
+++ b/example/src/main.rs
@@ -1,0 +1,3 @@
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    example::desktop_main()
+}


### PR DESCRIPTION
### Summary
Split the example crate into separate `src/main.rs` (desktop) and `src/lib.rs`
(Android cdylib + shared code) to eliminate Cargo’s duplicate‑target warning.

Closes #5

### Changes
* New `src/main.rs` with desktop `main()`
* Removed desktop `main()` from `src/lib.rs`
* Updated `example/Cargo.toml` to point `[[bin]]` at `src/main.rs`

### Notes
I couldn’t test the Android path because the current build fails in `arboard`
(clipboard backend not yet implemented on Android).  
Tracked separately in #9

