### PR TITLE
Fix non-posix pthread_setname_np call for apple platform

### DIFF
--- a/tessera-ui/src/thread_utils.rs
+++ b/tessera-ui/src/thread_utils.rs
@@ -134,6 +134,9 @@ fn set_thread_name_unix(name: &str) {
 
     unsafe {
         // Set the name for the current thread
+        #[cfg(target_vendor = "apple")]
+        libc::pthread_setname_np(cname.as_ptr());
+        #[cfg(not(target_vendor = "apple"))]
         libc::pthread_setname_np(libc::pthread_self(), cname.as_ptr());
     }
 }


### PR DESCRIPTION
It's a tricky one. See https://ffmpeg.org/pipermail/ffmpeg-cvslog/2024-May/143089.html for an example.