### PR TITLE
build(nix): add flake-based dev env

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,29 @@ If you need to contribute code to `tessera`, in addition to the latest stable Ru
 
 To ensure code quality and consistency, and to keep the repository clean, please follow these guidelines:
 
+## Getting Started
+
+### Option A - Nix package manager (one-liner)
+```bash
+nix develop            # desktop dev shell
+nix develop .#android  # android dev shell
+```
+
+### Option B - Manual setup
+
+Rust >= 1.77 (rustup toolchain install stable)
+
+Vulkan SDK (includes loader + headers)
+Download from https://vulkan.lunarg.com, run the installer, and
+follow its post‑install instructions.
+
+```bash
+# X11
+sudo apt install libxi-dev libxrandr-dev libxcursor-dev
+# Wayland
+sudo apt install libwayland-dev libxkbcommon-dev
+```
+
 ### Language for Code
 
 All code, including documentation within the code (like `rustdoc` comments) and comments, must be written in English, unless a feature specifically requires pointing out a word in another language.
@@ -46,6 +69,7 @@ All code, including documentation within the code (like `rustdoc` comments) and 
     ```bash
     rust-script scripts/check-imports.rs . --fix
     ```
+  - Nix users: just type `fmt` inside `nix develop` - it's a smart alias that runs the same command above from any directory
 
     This command checks and fixes import rules, and also calls `rustfmt` for formatting. It directly applies all the formatting rules mentioned above and does not ignore script files (whereas `cargo fmt` only formats what is managed by `Cargo.toml`).
 

--- a/README.md
+++ b/README.md
@@ -211,6 +211,26 @@ cargo run
    x run -p example --arch arm64 --device adb:823c4f8b
    ```
 
+## Getting started with Nix
+
+### Running the Example on Desktop
+```bash
+nix develop           # to enter the desktop shell
+cargo run -p example  # to build and run the example
+```
+
+### Running the Example on Android
+```bash
+# Enter the Android shell (includes all android tools and setup)
+nix develop
+
+# Find your device ID
+x devices
+
+# Assuming device ID is adb:823c4f8b and architecture is arm64
+x run -p example --arch arm64 --device adb:823c4f8b
+```
+
 ## Workspace Structure
 
 Tessera adopts a multi-crate workspace structure:

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,96 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1753115646,
+        "narHash": "sha256-yLuz5cz5Z+sn8DRAfNkrd2Z1cV6DaYO9JMrEz4KZo/c=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "92c2e04a475523e723c67ef872d8037379073681",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-25.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1744536153,
+        "narHash": "sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "18dd725c29603f582cf1900e0d25f9f1063dbf11",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1753238793,
+        "narHash": "sha256-jmQeEpgX+++MEgrcikcwoSiI7vDZWLP0gci7XiWb9uQ=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "0ad7ab4ca8e83febf147197e65c006dff60623ab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,121 @@
+/*
+  This file is **only** for users of the Nix package manager
+  (https://nixos.org/).  If you’re on:
+
+    - macOS without nix‑darwin
+    - Windows without Nix/WSL
+
+  ...you can safely ignore it.
+
+  For Nix users it defines:
+    - all required packages
+    - environment variables
+    - handy dev‑shell aliases (e.g. `fmt`)
+
+  Quick start: see “Getting Started with Nix” in README.md or CONTRIBUTING.md.
+*/
+{
+  description = "Tessera UI dev env (desktop default, Android optional)";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.05";
+    flake-utils.url = "github:numtide/flake-utils";
+    rust-overlay.url = "github:oxalica/rust-overlay";
+  };
+
+  outputs =
+    {
+      nixpkgs,
+      flake-utils,
+      rust-overlay,
+      ...
+    }:
+    (flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [ rust-overlay.overlays.default ];
+
+          config.allowUnfree = true; # bcs android unfree license
+          config.android_sdk.accept_license = true; # silence license prompt
+        };
+
+        rust = pkgs.rust-bin.stable.latest.default;
+
+        gfx = with pkgs; [
+          wayland
+          libxkbcommon
+          xorg.libX11
+          xorg.libXcursor
+          xorg.libXrandr
+          xorg.libXi
+          vulkan-loader
+          vulkan-headers
+        ];
+
+        # Android payload (only for android shell)
+        android = pkgs.androidenv.composeAndroidPackages {
+          platformVersions = [ "34" ];
+          buildToolsVersions = [ "34.0.0" ];
+          abiVersions = [ "arm64-v8a" ];
+          includeNDK = true;
+          includeEmulator = false;
+        };
+        sdkRoot = "${android.androidsdk}/libexec/android-sdk";
+      in
+      {
+        devShells = {
+          # desktop‑only shell
+          default = pkgs.mkShell {
+            buildInputs = [
+              rust
+              pkgs.pkg-config
+            ]
+            ++ gfx;
+            LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath gfx;
+            shellHook = ''
+              echo "Setting up fmt command..."
+              ${sharedShellHook}
+              echo "Desktop shell ready."
+            '';
+          };
+
+          # full blown android shell
+          android = pkgs.mkShell {
+            buildInputs = [
+              pkgs.rustup
+              pkgs.pkg-config
+              pkgs.openssl.dev
+              pkgs.openssl
+              android.androidsdk
+              pkgs.cargo-ndk
+            ]
+            ++ gfx;
+
+            LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath gfx;
+            PKG_CONFIG_PATH = pkgs.lib.makeSearchPath "lib/pkgconfig" [ pkgs.openssl.dev ];
+
+            shellHook = ''
+              echo "Setting up fmt command..."
+              ${sharedShellHook}
+
+              echo "Setting up env vars..."
+              export ANDROID_HOME=${sdkRoot}
+              export ANDROID_NDK_HOME=$ANDROID_HOME/ndk-bundle
+              export PATH="$PATH:$ANDROID_HOME/platform-tools:$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin"
+
+              echo "Setting up rust toolchain..."
+              # ensure a minimal stable toolchain + std‑lib for Android
+              rustup --quiet toolchain install stable || true
+              rustup --quiet target add aarch64-linux-android || true
+
+              echo "Installing xbuild..."
+              command -v x >/dev/null || cargo install xbuild --features vendored  # vendor OpenSSL
+              echo "Android shell ready (adb / NDK / xbuild / cross‑std)."
+            '';
+          };
+        };
+      }
+    ));
+}


### PR DESCRIPTION
## Why
New contributors had to install Rust + graphics libs + Android toolchain manually. A Nix flake gives them a one‑command dev shell (nix develop) for desktop or Android.

## How to test
```
# Desktop dev shell
nix develop

# Android dev shell
nix develop .#android
```
Run `fmt` anywhere inside/outside the repo -> formats imports via rust-script.

## Housekeeping
- Closes #12 
- Updates README + CONTRIBUTING

## Next steps
The new *Manual Setup* section in **CONTRIBUTING.md** is mostly guesswork right now. We probably need either:

- A proper, distro‑specific guide (Ubuntu, Arch, macOS, Windows) **or**
- Helper scripts:
  - `bootstrap.sh` (POSIX)
  - `bootstrap.ps1` (PowerShell)

I’m happy to write `bootstrap.sh`, but I’ll need more time (and maybe a PowerShell‑savvy volunteer) for `bootstrap.ps1`.

Tracking in #15 